### PR TITLE
Build kawpow on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ cable_configure_toolchain(DEFAULT cxx11)
 set(HUNTER_CONFIGURATION_TYPES Release CACHE STRING "Build type of Hunter packages")
 set(HUNTER_JOBS_NUMBER 6 CACHE STRING "Number of parallel builds used by Hunter")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.214.tar.gz"
-    SHA1 "e14bc153a7f16d6a5eeec845fb0283c8fad8c358"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.23.253.tar.gz"
+    SHA1 "88ea6d37c897a81a080eb9ae0f69d7807bbb3c73"
 	LOCAL
 )
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,5 +1,5 @@
 hunter_config(CURL VERSION ${HUNTER_CURL_VERSION} CMAKE_ARGS HTTP_ONLY=ON CMAKE_USE_OPENSSL=ON CMAKE_USE_LIBSSH2=OFF CURL_CA_PATH=none)
-hunter_config(Boost VERSION 1.70.0-p0)
+hunter_config(Boost VERSION 1.72.0-p1)
 
 hunter_config(ethash VERSION 1.0.0
     URL https://github.com/RavenCommunity/cpp-kawpow/archive/1.1.0.tar.gz

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -469,7 +469,7 @@ void CLMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollection
     {
         std::string platformName = platforms.at(pIdx).getInfo<CL_PLATFORM_NAME>();
         ClPlatformTypeEnum platformType = ClPlatformTypeEnum::Unknown;
-        if (platformName == "AMD Accelerated Parallel Processing")
+        if (platformName == "AMD Accelerated Parallel Processing" || platformName == "Apple")
             platformType = ClPlatformTypeEnum::Amd;
         else if (platformName == "Clover")
             platformType = ClPlatformTypeEnum::Clover;

--- a/libethash-cl/CLMiner_kernel.cl
+++ b/libethash-cl/CLMiner_kernel.cl
@@ -174,8 +174,8 @@ ethash_search(__global struct SearchResults* restrict g_output, __constant hash3
     if (g_output->abort)
         return;
 
-    __local shuffle_t share[HASHES_PER_GROUP];
-    __local uint32_t c_dag[PROGPOW_CACHE_WORDS];
+    shuffle_t share[HASHES_PER_GROUP];
+    uint32_t c_dag[PROGPOW_CACHE_WORDS];
 
     uint32_t const lid = get_local_id(0);
     uint32_t const gid = get_global_id(0);

--- a/libprogpow/ProgPow.cpp
+++ b/libprogpow/ProgPow.cpp
@@ -114,8 +114,8 @@ std::string ProgPow::getKern(uint64_t prog_seed, kernel_t kern)
         ret << "inline void progPowLoop(const uint32_t loop,\n";
         ret << "        volatile uint32_t mix_arg[PROGPOW_REGS],\n";
         ret << "        __global const dag_t *g_dag,\n";
-        ret << "        __local const uint32_t c_dag[PROGPOW_CACHE_WORDS],\n";
-        ret << "        __local uint64_t share[GROUP_SHARE],\n";
+        ret << "        const uint32_t c_dag[PROGPOW_CACHE_WORDS],\n";
+        ret << "        uint64_t share[GROUP_SHARE],\n";
         ret << "        const bool hack_false)\n";
     }
     ret << "{\n";


### PR DESCRIPTION
These changes get kawpow to build on OSX (Catalina 10.15.4) however it still doesn't mine. Perhaps someone with an iGPU (I'm using an eGPU) can try it out:

```
[CL_DEVICE_NOT_AVAILABLE] : OpenCL Error : Error: Build Program driver returned (517)
Break on OpenCLErrorBreak to debug.
OpenCL Warning : clBuildProgram failed: could not build program for 0x1021c00 (AMD Radeon RX 570 Compute Engine) (err:-2)
Break on OpenCLWarningBreak to debug.
[CL_BUILD_ERROR] : OpenCL Build Error : Compiler build log:
Error returned by cvms_element_build_from_source

Break on OpenCLErrorBreak to debug.
```
