### PR TITLE
Fix for nvrtc issues on Ubuntu 20.04 and newer CUDA releases

### DIFF
--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -50,8 +50,8 @@ file(GLOB headers CUDAMiner.h CUDAMiner_cuda.h ${CMAKE_CURRENT_BINARY_DIR}/CUDAM
 cuda_add_library(ethash-cuda STATIC ${sources} ${headers})
 add_dependencies(ethash-cuda cuda_kernel)
 # Cmake doesn't handle nvrtc automatically
-find_library(CUDA_nvrtc_LIBRARY NAMES nvrtc PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES /lib/x86_64-linux-gnu lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
-find_library(CUDA_cuda_LIBRARY NAMES cuda PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES /lib/x86_64-linux-gnu lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
+find_library(CUDA_nvrtc_LIBRARY NAMES nvrtc PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib/x86_64-linux-gnu lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
+find_library(CUDA_cuda_LIBRARY NAMES cuda PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib/x86_64-linux-gnu lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
 target_link_libraries(ethash-cuda ethcore ethash::ethash progpow Boost::thread)
 target_link_libraries(ethash-cuda ${CUDA_nvrtc_LIBRARY} ${CUDA_cuda_LIBRARY})
 target_include_directories(ethash-cuda PUBLIC ${CUDA_INCLUDE_DIRS})

--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -50,8 +50,8 @@ file(GLOB headers CUDAMiner.h CUDAMiner_cuda.h ${CMAKE_CURRENT_BINARY_DIR}/CUDAM
 cuda_add_library(ethash-cuda STATIC ${sources} ${headers})
 add_dependencies(ethash-cuda cuda_kernel)
 # Cmake doesn't handle nvrtc automatically
-find_library(CUDA_nvrtc_LIBRARY NAMES nvrtc PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
-find_library(CUDA_cuda_LIBRARY NAMES cuda PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
+find_library(CUDA_nvrtc_LIBRARY NAMES nvrtc PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES /lib/x86_64-linux-gnu lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
+find_library(CUDA_cuda_LIBRARY NAMES cuda PATHS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES /lib/x86_64-linux-gnu lib64 lib/x64 lib64/stubs lib/x64/stubs lib NO_DEFAULT_PATH)
 target_link_libraries(ethash-cuda ethcore ethash::ethash progpow Boost::thread)
 target_link_libraries(ethash-cuda ${CUDA_nvrtc_LIBRARY} ${CUDA_cuda_LIBRARY})
 target_include_directories(ethash-cuda PUBLIC ${CUDA_INCLUDE_DIRS})


### PR DESCRIPTION
This might also possibly address related issues like  #11 

With newer Ubuntu versions like 20.04 installing the cuda packages via `apt` sends them to `/lib/x86_64-linux-gnu`. 