### PR TITLE
Fix in issue #42

### DIFF
--- a/kawpowminer/main.cpp
+++ b/kawpowminer/main.cpp
@@ -112,7 +112,7 @@ public:
             minelog << logLine;
 
 #if ETH_DBUS
-            dbusint.send(Farm::f().Telemetry().str());
+            dbusint.send(Farm::f().Telemetry().str().c_str());
 #endif
             // Resubmit timer
             m_cliDisplayTimer.expires_from_now(boost::posix_time::seconds(m_cliDisplayInterval));


### PR DESCRIPTION
I was able to compile this locally and am able to run kawpowminer on my workstation after this fix.
Submitting PR for review and discussion as I believe this might help other folks.

Using gcc-9 (Ubuntu 9.3.0-18ubuntu1) 9.3.0.
Kernel 5.8.0-7630-generic.

Are others able to confirm so we can merge? Thanks!