### PR TITLE
Fix lack of uniqueId on AMD GPU OpenCL without AMD extensions

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,5 +1,5 @@
 hunter_config(CURL VERSION ${HUNTER_CURL_VERSION} CMAKE_ARGS HTTP_ONLY=ON CMAKE_USE_OPENSSL=ON CMAKE_USE_LIBSSH2=OFF CURL_CA_PATH=none)
-hunter_config(Boost VERSION 1.70.0-p0)
+hunter_config(Boost VERSION ${HUNTER_Boost_VERSION})
 
 hunter_config(ethash VERSION 1.0.0
     URL https://github.com/RavenCommunity/cpp-kawpow/archive/1.1.0.tar.gz

--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -515,17 +515,42 @@ void CLMiner::enumDevices(std::map<string, DeviceDescriptor>& _DevicesCollection
                       << (unsigned int)(slot_id >> 3) << "." << (unsigned int)(slot_id & 0x7);
                     uniqueId = s.str();
                 }
+                else
+                {
+                   /* No Nvidia extensions */
+                   std::ostringstream s;
+                   s << "Nvidia:" << pIdx << "." << dIdx;
+                   uniqueId = s.str();
+                }
             }
             else if (clDeviceType == DeviceTypeEnum::Gpu &&
                      (platformType == ClPlatformTypeEnum::Amd ||
                          platformType == ClPlatformTypeEnum::Clover))
             {
-                cl_char t[24];
-                if (clGetDeviceInfo(device.get(), 0x4037, sizeof(t), &t, NULL) == CL_SUCCESS)
+                struct amd_topo {
+                    cl_char padding[21];
+                    cl_char bus;
+                    cl_char device;
+                    cl_char function;
+                } amd_topo;
+                if (clGetDeviceInfo(device.get(), CL_DEVICE_TOPOLOGY_AMD, 
+                                    sizeof(amd_topo), &amd_topo, NULL) 
+                    == CL_SUCCESS)
                 {
                     std::ostringstream s;
-                    s << setfill('0') << setw(2) << hex << (unsigned int)(t[21]) << ":" << setw(2)
-                      << (unsigned int)(t[22]) << "." << (unsigned int)(t[23]);
+                    s << setfill('0') << setw(2) << hex
+                      << (unsigned int)(amd_topo.bus)
+                      << ":" << setw(2)
+                      << (unsigned int)(amd_topo.device)
+                      << "."
+                      << (unsigned int)(amd_topo.function);
+                    uniqueId = s.str();
+                }
+                else
+                {
+                    /* No AMD extensions */
+                    std::ostringstream s;
+                    s << "AMD:" << pIdx << "." << dIdx;
                     uniqueId = s.str();
                 }
             }

--- a/libethash-cl/CLMiner.h
+++ b/libethash-cl/CLMiner.h
@@ -26,6 +26,7 @@
 #define CL_HPP_TARGET_OPENCL_VERSION 120
 #define CL_HPP_MINIMUM_OPENCL_VERSION 120
 #include "CL/cl2.hpp"
+#include <CL/cl_ext.h>
 #pragma GCC diagnostic pop
 
 // macOS OpenCL fix:
@@ -35,6 +36,10 @@
 
 #ifndef CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV
 #define CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV 0x4001
+#endif
+
+#ifndef CL_DEVICE_TOPOLOGY_AMD
+#define CL_DEVICE_TOPOLOGY_AMD  0x4037
 #endif
 
 namespace dev


### PR DESCRIPTION
AMD GPU systems need not have a functional
clGetDeviceInfo(..., CL_DEVICE_TOPOLOGY_AMD, ...).

E.g., Fedora OpenCL with AMD GPU drivers, it seems. As the code stands it
doesn't create a uniqueId, and leaves it null. If there are multiple GPUs,
the device info is stored to null uniqueId and overwritten - and only one of
these GPUs will be enumerated and visible to the miner.

Fix this by providing a fall-back, constructing the uniqueId from the
platform and device indexes. As is already the case for Intel GPU and CPU
devices.

Additionally, cosmetically, add a clearer, more self-describing struct for
the AMD topology data.

To get Hunter to work I had to update the Boost version.
The previously specified version is no longer available for hunter to download.